### PR TITLE
feat(local): add local docker run setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Copy this file to .env and fill in the values before running locally
+# Used by docker-compose.local.yml
+
+# App DB connection - use the credentials you have access to
+# PI_DB_HOST: use 'pi-db' for local MySQL container, or a remote host
+PI_DB_HOST=pi-db
+PI_DB_USER=root
+PI_DB_PASSWORD=root
+
+# Database names
+PI_DB_DIVA_NAME=hant_diva
+PI_DB_ISBN_NAME=hant_isbn
+PI_DB_BIBMET_NAME=bibmet
+
+# Only needed when running the local pi-db container.
+# Defaults to 'localroot' if not set - fine for local use only.
+# MYSQL_ROOT_PASSWORD=CHANGE_ME

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,28 @@
+FROM php:7.3-apache
+
+RUN a2enmod rewrite && \
+cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini && \
+docker-php-ext-install mysqli pdo pdo_mysql && \
+apt-get update && \
+apt-get -y install nano locales && \
+sed -i '/en_GB.UTF-8/s/^# //g' /etc/locale.gen && \
+locale-gen && \
+sed -i '/sv_SE.UTF-8/s/^# //g' /etc/locale.gen && \
+locale-gen
+
+ENV LANG en_GB.UTF-8
+ENV LANGUAGE en_GB:en
+ENV LC_ALL en_GB.UTF-8
+
+# Disable error display
+RUN sed -i -e 's/^display_errors\s*=\s*On/display_errors = Off/g' $PHP_INI_DIR/php.ini
+
+# Allow slightly larger uploads for local testing
+RUN sed -i -e 's/upload_max_filesize = 2M/upload_max_filesize = 20M/g' $PHP_INI_DIR/php.ini && \
+    sed -i -e 's/post_max_size = 8M/post_max_size = 20M/g' $PHP_INI_DIR/php.ini
+
+COPY ./src /var/www/html
+
+# Ensure upload directories are writable by Apache user
+RUN mkdir -p /var/www/html/PI/DiVA/DATAFILER /var/www/html/PI/sqlserwebb/DATAFILER && \
+    chown -R www-data:www-data /var/www/html/PI/DiVA/DATAFILER /var/www/html/PI/sqlserwebb/DATAFILER

--- a/README.md
+++ b/README.md
@@ -141,3 +141,9 @@ Local setup uses:
 - Local DB config is provided through:
   - `src/PI/DiVA/config.php.inc`
   - `src/PI/ISBN/config.php.inc`
+
+## Architecture and Flow
+
+For a project overview with Mermaid charts (architecture, navigation, and data flow), see:
+
+- `README_FLOW.md`

--- a/README.md
+++ b/README.md
@@ -92,7 +92,52 @@ REPO_TYPE=ref
 12. Github Actions bygger en dockerimage i github packages
 13. Starta applikationen med docker compose up -d --build i "local/docker/pi"
 
+## Local Development (without Traefik)
 
+Use the dedicated local compose file: `docker-compose.local.yml`.
 
+Local setup uses:
 
+- local image build from this repository (no GHCR pull)
+- `Dockerfile.local` (skips SQL Server ODBC installation for local use)
+- internal bridge network (no external `apps-net` required)
+- MySQL initialization from `dbinit/`
+- ports `8080` (web) and `3307` (MySQL)
 
+### Step-by-step: run locally
+
+1. Open a terminal in the repository root.
+
+2. Build and start containers:
+   - `docker compose -f docker-compose.local.yml up -d --build`
+
+3. Verify containers are running:
+   - `docker compose -f docker-compose.local.yml ps`
+
+4. Open the app:
+   - `http://localhost:8080/PI/DiVA/index.php`
+
+5. (Optional) Follow logs:
+   - `docker compose -f docker-compose.local.yml logs -f`
+
+6. Stop containers:
+   - `docker compose -f docker-compose.local.yml down`
+
+7. Stop and remove database volume (reset local DB):
+   - `docker compose -f docker-compose.local.yml down -v`
+
+### Troubleshooting
+
+- If you previously tried to build with `Dockerfile` and saw `msodbcsql17` errors, use only:
+  - `docker compose -f docker-compose.local.yml up -d --build`
+- If `8080` or `3307` is already in use, stop conflicting services and run again.
+- If you changed SQL files under `dbinit/`, recreate the DB volume:
+  - `docker compose -f docker-compose.local.yml down -v`
+  - `docker compose -f docker-compose.local.yml up -d --build`
+
+### Notes
+
+- `docker-compose.yml` is production-oriented and expects external networking and environment variables for GHCR/Traefik.
+- Local DB config is provided through:
+  - `src/PI/DiVA/config.php.inc`
+  - `src/PI/ISBN/config.php.inc`

--- a/README.md
+++ b/README.md
@@ -1,22 +1,25 @@
 # KTH Bibliotekets Tjänster för Publiceringens Infrastruktur(PI)
 
 ## Funktioner
+
 Startas i en Dockercontainer
 
 ###
+
 Deploy via github actions som anropar en webhook
 
 ### Hanterar ISBN, Leta KTH-anställda, Adressrättning DiVA, BIBMET
 
 #### Dependencies
+
 php:7.3-apache
 mysqli pdo pdo_mysql
 
-
 ##### Installation
 
-1.  Skapa folder på server med namnet på repot: "/local/docker/pi"
-2.  Skapa och anpassa docker-compose.yml i foldern
+1. Skapa folder på server med namnet på repot: "/local/docker/pi"
+2. Skapa och anpassa docker-compose.yml i foldern
+
 ```txt
 version: "3.6"
 
@@ -69,7 +72,8 @@ networks:
     external: true
 ```
 
-3.  Skapa och anpassa .env(för composefilen) i foldern
+1. Skapa och anpassa .env(för composefilen) i foldern
+
 ```
 DB_DATABASE=pi
 DB_USER=pi_anv
@@ -80,17 +84,16 @@ DOMAIN_NAME=apps-ref.lib.kth.se
 REPO_TYPE=ref
 ```
 
-
-4. Skapa folder "local/docker/pi/dbinit"
-5. Skapa init.sql från repots dbinit/init.sql
-6. Skapa folder /local/docker/pi/DiVA/sqlserwebb/DATAFILER
-7. Sätt rättigheter/ägare: sudo chown -R www-data:www-data /local/docker/pi/DiVA/sqlserwebb/DATAFILER
-8. Skapa folder /local/docker/pi/DiVA/DATAFILER
-9. Sätt rättigheter/ägare: sudo chown -R www-data:www-data /local/docker/pi/DiVA/DATAFILER
-10. Skapa deploy_ref.yml i github actions
-11. Skapa deploy_prod.yml i github actions
-12. Github Actions bygger en dockerimage i github packages
-13. Starta applikationen med docker compose up -d --build i "local/docker/pi"
+1. Skapa folder "local/docker/pi/dbinit"
+2. Skapa init.sql från repots dbinit/init.sql
+3. Skapa folder /local/docker/pi/DiVA/sqlserwebb/DATAFILER
+4. Sätt rättigheter/ägare: sudo chown -R www-data:www-data /local/docker/pi/DiVA/sqlserwebb/DATAFILER
+5. Skapa folder /local/docker/pi/DiVA/DATAFILER
+6. Sätt rättigheter/ägare: sudo chown -R www-data:www-data /local/docker/pi/DiVA/DATAFILER
+7. Skapa deploy_ref.yml i github actions
+8. Skapa deploy_prod.yml i github actions
+9. Github Actions bygger en dockerimage i github packages
+10. Starta applikationen med docker compose up -d --build i "local/docker/pi"
 
 ## Local Development (without Traefik)
 
@@ -141,6 +144,120 @@ Local setup uses:
 - Local DB config is provided through:
   - `src/PI/DiVA/config.php.inc`
   - `src/PI/ISBN/config.php.inc`
+
+### Local Endpoints
+
+All URLs assume the app is running at `http://localhost:8080`.
+
+> **Note:** Most pages require a valid session. Log in first via the relevant login page before navigating to protected pages.
+
+---
+
+#### DiVA / ISBN module
+
+### Login
+
+| URL | Description |
+|-----|-------------|
+| `http://localhost:8080/PI/DiVA/index.php` | Start page |
+| `http://localhost:8080/PI/DiVA/d_loggain.php` | DiVA login (credentials stored in `hant_diva` MySQL; use `root`/`root` locally) |
+| `http://localhost:8080/PI/DiVA/d_h_loggain.php` | DiVA historical data login |
+| `http://localhost:8080/PI/DiVA/loggain.php` | ISBN login (credentials stored in `hant_isbn` MySQL; redirects to ISBN menu) |
+
+### Menus
+
+| URL | Description |
+|-----|-------------|
+| `http://localhost:8080/PI/DiVA/d_meny.php` | DiVA main menu |
+| `http://localhost:8080/PI/DiVA/d_h_meny.php` | DiVA historical data menu |
+| `http://localhost:8080/PI/DiVA/d_importmeny.php` | DiVA import menu |
+| `http://localhost:8080/PI/DiVA/d_isbn_meny.php` | ISBN sub-menu |
+
+### Staff search
+
+| URL | Description |
+|-----|-------------|
+| `http://localhost:8080/PI/DiVA/d_soek_personal.php` | Search KTH staff |
+| `http://localhost:8080/PI/DiVA/d_visa_personal.php` | View staff member details |
+
+### ISBN management
+
+| URL | Description |
+|-----|-------------|
+| `http://localhost:8080/PI/DiVA/d_soek_isbn.php` | Search ISBN records |
+| `http://localhost:8080/PI/DiVA/d_visa_valt_isbn.php` | View selected ISBN record |
+| `http://localhost:8080/PI/DiVA/d_visa_reg_isbn.php` | View registered ISBNs |
+| `http://localhost:8080/PI/DiVA/d_visa_statistik.php` | ISBN registration statistics (monthly) |
+| `http://localhost:8080/PI/DiVA/d_aendra_isbnreg.php` | Edit ISBN registration |
+| `http://localhost:8080/PI/DiVA/d_ladda_isbn.php` | Upload/import ISBN file |
+
+### File processing & restore
+
+| URL | Description |
+|-----|-------------|
+| `http://localhost:8080/PI/DiVA/d_behandlafil_man_m_l.php` | Manual file processing |
+| `http://localhost:8080/PI/DiVA/d_behandlafil_man_m_l_25.php` | Manual file processing (variant) |
+| `http://localhost:8080/PI/DiVA/d_aterstall.php` | Restore/reset records |
+| `http://localhost:8080/PI/DiVA/d_aterstall_2.php` | Restore/reset records (step 2) |
+
+---
+
+#### BIBSTAT / sqlserwebb module
+
+> **Note:** This module connects to SQL Server at `bibmet01.ug.kth.se`. Requires KTH network or VPN. The local Docker image is built for `linux/amd64` to support the Microsoft ODBC driver.
+
+### Entry & menu
+
+| URL | Description |
+|-----|-------------|
+| `http://localhost:8080/PI/sqlserwebb/loggain.php` | BIBSTAT login — starts SQL Server session |
+| `http://localhost:8080/PI/sqlserwebb/adressmeny.php` | BIBSTAT main menu (after login) |
+
+### Primary feature pages (accessible from menu)
+
+| URL | Description |
+|-----|-------------|
+| `http://localhost:8080/PI/sqlserwebb/regel_organisation.php` | Organisation matching rules |
+| `http://localhost:8080/PI/sqlserwebb/regel_full_adress.php` | Full-address matching rules |
+| `http://localhost:8080/PI/sqlserwebb/regel_centra.php` | Centra matching rules |
+| `http://localhost:8080/PI/sqlserwebb/regel_organisation_typ.php` | Organisation-type matching rules |
+| `http://localhost:8080/PI/sqlserwebb/organisationsnamn.php` | Organisation name lookup |
+| `http://localhost:8080/PI/sqlserwebb/laddaorgregler.php` | Load/import organisation rules |
+| `http://localhost:8080/PI/sqlserwebb/senaste_koerning.php` | Latest rule-run results |
+| `http://localhost:8080/PI/sqlserwebb/regel_ej_traeff.php` | Rules with no matches |
+| `http://localhost:8080/PI/sqlserwebb/bestaell_listor.php` | Order/export lists |
+
+### Secondary pages (reached from feature pages)**
+
+| URL | Description |
+|-----|-------------|
+| `http://localhost:8080/PI/sqlserwebb/visa_regler_o.php` | View organisation rules |
+| `http://localhost:8080/PI/sqlserwebb/visa_regler_f_a.php` | View full-address rules |
+| `http://localhost:8080/PI/sqlserwebb/visa_regler_c.php` | View centra rules |
+| `http://localhost:8080/PI/sqlserwebb/visa_regler_o_typ.php` | View organisation-type rules |
+| `http://localhost:8080/PI/sqlserwebb/visa_regler_unorgid.php` | View rules for unknown org IDs |
+| `http://localhost:8080/PI/sqlserwebb/visa_regler_ej_traeff.php` | View rules with no hits |
+| `http://localhost:8080/PI/sqlserwebb/visa_organisation.php` | View organisation record |
+| `http://localhost:8080/PI/sqlserwebb/visa_dubb_c.php` | View centra duplicates |
+| `http://localhost:8080/PI/sqlserwebb/splittringsdubbletter.php` | Split/merge duplicate records |
+| `http://localhost:8080/PI/sqlserwebb/ny_regel_o.php` | Add new organisation rule |
+| `http://localhost:8080/PI/sqlserwebb/ny_regel_f_a.php` | Add new full-address rule |
+| `http://localhost:8080/PI/sqlserwebb/ny_regel_c.php` | Add new centra rule |
+| `http://localhost:8080/PI/sqlserwebb/ny_regel_o_typ.php` | Add new organisation-type rule |
+| `http://localhost:8080/PI/sqlserwebb/ny_organisation.php` | Add new organisation |
+| `http://localhost:8080/PI/sqlserwebb/aendra_regel_o.php` | Edit organisation rule |
+| `http://localhost:8080/PI/sqlserwebb/aendra_regel_f_a.php` | Edit full-address rule |
+| `http://localhost:8080/PI/sqlserwebb/aendra_regel_c.php` | Edit centra rule |
+| `http://localhost:8080/PI/sqlserwebb/aendra_regel_o_typ.php` | Edit organisation-type rule |
+| `http://localhost:8080/PI/sqlserwebb/aendra_organisation.php` | Edit organisation |
+| `http://localhost:8080/PI/sqlserwebb/koer_regel_o.php` | Run organisation rule |
+| `http://localhost:8080/PI/sqlserwebb/koer_regel_c.php` | Run centra rule |
+| `http://localhost:8080/PI/sqlserwebb/koer_regel_o_typ.php` | Run organisation-type rule |
+| `http://localhost:8080/PI/sqlserwebb/lista_1.php` | List view 1 |
+| `http://localhost:8080/PI/sqlserwebb/lista_2.php` | List view 2 |
+| `http://localhost:8080/PI/sqlserwebb/traeff_regler_o_typ.php` | Organisation-type rule hits |
+
+---
 
 ## Architecture and Flow
 

--- a/README.md
+++ b/README.md
@@ -147,3 +147,9 @@ Local setup uses:
 For a project overview with Mermaid charts (architecture, navigation, and data flow), see:
 
 - `README_FLOW.md`
+
+## Modernization Guide
+
+For a repo-specific plan to improve or rewrite PI into a more coherent production-ready system, see:
+
+- `README_REWRITE.md`

--- a/README_FLOW.md
+++ b/README_FLOW.md
@@ -1,0 +1,135 @@
+# PI Project Guide and Flow
+
+## What this project is about
+
+PI is a legacy PHP web application used by KTH Library to support publishing-related workflows.
+
+Main business areas:
+- DiVA import processing (file-based workflow)
+- ISBN handling (register/search/statistics)
+- KTH staff lookup support
+- Address correction/rule management in the sqlserwebb module
+
+The system runs in Docker and uses MySQL for DiVA/ISBN/BIBMET-related tables.
+Some modules in sqlserwebb also connect to Microsoft SQL Server through PDO sqlsrv.
+
+## Main modules
+
+- src/PI/DiVA
+  - Main entry for menu and import workflows
+  - Uses MySQL databases such as hant_diva, hant_isbn, and bibmet
+- src/PI/ISBN
+  - ISBN registration endpoints and related actions
+  - Uses MySQL (hant_isbn)
+- src/PI/sqlserwebb
+  - Address/rule management area
+  - Uses SQL Server (PDO sqlsrv) in many scripts
+- dbinit
+  - SQL initialization scripts for local MySQL startup
+  - bibmet.sql, hant_diva.sql, hant_isbn.sql
+
+## High-level architecture
+
+```mermaid
+flowchart LR
+    U[User Browser] --> W[Apache + PHP Container]
+
+    subgraph APP[PI PHP Application]
+      D[DiVA module]
+      I[ISBN module]
+      S[sqlserwebb module]
+      M[PHPMailer]
+    end
+
+    W --> D
+    W --> I
+    W --> S
+
+    D --> MY[(MySQL)]
+    I --> MY
+    D --> M
+
+    S --> MSSQL[(SQL Server)]
+
+    subgraph LOCAL[Local docker-compose.local.yml]
+      W
+      MY
+    end
+```
+
+## Navigation flow (typical)
+
+```mermaid
+flowchart TD
+  A["/PI/DiVA/index.php"] --> B["d_importmeny.php"]
+  B --> C["d_behandlafil_man_m_l_25.php"]
+    C --> D[Parse uploaded txt file]
+    D --> E[Store processing rows in MySQL tables]
+    E --> F[Generate output files]
+    F --> G[Send result mail via PHPMailer]
+
+  A -. legacy menu path .-> H["d_meny.php"]
+  H --> I["d_soek_personal.php"]
+  H --> J["d_isbn_meny.php"]
+  J --> K["d_ladda_isbn.php"]
+  J --> L["d_soek_isbn.php"]
+  J --> M["d_visa_statistik.php"]
+```
+
+## ISBN registration flow
+
+```mermaid
+sequenceDiagram
+    participant Client as External form/client
+    participant PHP as /PI/ISBN/spara.php
+    participant DB as MySQL (hant_isbn)
+
+    Client->>PHP: POST publication and author fields
+    PHP->>DB: Check min ISBN threshold
+    PHP->>DB: Validate duplicate title/type/KTH id
+    alt Not duplicate
+      PHP->>DB: Transaction: reserve ISBN from oanv_isbn
+      PHP->>DB: Insert into reg_isbn
+      PHP-->>Client: Return assigned ISBN confirmation
+    else Duplicate
+      PHP-->>Client: Return already assigned message
+    end
+```
+
+## Data stores used in PI
+
+```mermaid
+flowchart LR
+    D[DiVA workflows] --> HD[(hant_diva)]
+    I[ISBN workflows] --> HI[(hant_isbn)]
+    P[Import processing] --> BM[(bibmet)]
+    R[sqlserwebb rules] --> BS[(BIBSTAT SQL Server)]
+```
+
+## Local runtime model
+
+For local development, the repository includes:
+
+- docker-compose.local.yml
+- Dockerfile.local
+
+Why this matters:
+
+- Local profile skips SQL Server ODBC installation to avoid build issues with old package sources.
+- DiVA/ISBN/MySQL flows work locally.
+- sqlserwebb pages that require SQL Server connectivity may not fully work unless SQL Server access is available and configured.
+
+## Key entry points
+
+- DiVA menu: /PI/DiVA/index.php
+- Import menu: /PI/DiVA/d_importmeny.php
+- Legacy main menu: /PI/DiVA/d_meny.php
+- ISBN menu: /PI/DiVA/d_isbn_meny.php
+- sqlserwebb login: /PI/sqlserwebb/loggain.php
+
+## Quick understanding summary
+
+- PI is a multi-workflow PHP app, not a single API service.
+- Most local functionality depends on MySQL and dbinit scripts.
+- sqlserwebb is the main part that depends on SQL Server.
+- The primary current start page leads into the DiVA import flow.

--- a/README_REWRITE.md
+++ b/README_REWRITE.md
@@ -1,0 +1,439 @@
+# PI Modernization and Rewrite Guide
+
+## Purpose
+
+This document describes how to improve and gradually rewrite PI into a more coherent, maintainable, and production-ready system.
+
+The goal is not to replace everything in one step. The safer approach is to stabilize the current application first, then extract clear boundaries, and only then modernize the internals.
+
+## Current state
+
+The repository is a legacy multi-page PHP application with these characteristics:
+
+- plain PHP scripts with HTML mixed into request handlers
+- direct database access from page scripts
+- manual includes and shared globals/session state
+- multiple business areas in one codebase: DiVA, ISBN, BIBMET, sqlserwebb
+- mixed data sources: MySQL plus SQL Server for sqlserwebb
+- infrastructure assumptions embedded in the app and container setup
+- partial configuration via mounted files instead of a clear runtime config model
+
+This works, but it creates predictable problems:
+
+- business logic is hard to find and reuse
+- database logic is duplicated across scripts
+- configuration and secrets are easy to misconfigure
+- local, test, and production runtime behavior differ too much
+- the application has no clear domain boundaries or deployment contracts
+- testing is difficult because page scripts do too much work directly
+
+## Main problems to solve
+
+### 1. No application structure
+
+The code is organized mostly by pages and actions, not by domain or responsibility.
+
+Result:
+
+- one file often handles request parsing, validation, SQL, formatting, and response rendering
+- changes in one workflow are easy to break elsewhere
+
+### 2. Database access is tightly coupled to page scripts
+
+SQL is embedded directly inside UI-facing PHP files.
+
+Result:
+
+- no reusable data layer
+- difficult transaction handling
+- difficult testing and review
+
+### 3. Configuration is inconsistent
+
+The app uses mounted config files and legacy assumptions around paths, credentials, and runtime state.
+
+Result:
+
+- fragile deployments
+- environment drift between local and production
+- secrets management is weaker than it should be
+
+### 4. Production readiness is incomplete
+
+The current repo can run, but it is missing the usual production-grade concerns as first-class parts of the system.
+
+Examples:
+
+- structured logging
+- health checks
+- application metrics
+- error tracking
+- automated tests in CI
+- dependency update strategy
+- security hardening and secret rotation
+
+### 5. Module boundaries are unclear
+
+The repository contains several concerns:
+
+- DiVA workflows
+- ISBN workflows
+- BIBMET import processing
+- sqlserwebb SQL Server-backed rules management
+- email sending
+
+These should not all evolve as one flat PHP surface.
+
+## Recommended target architecture
+
+Do not start with a big-bang rewrite. Use a staged modernization strategy.
+
+Target shape:
+
+- one deployable application, or a small number of clearly separated services
+- clear modules with explicit boundaries
+- framework-supported routing, dependency injection, validation, logging, and configuration
+- business logic moved out of page scripts into services/use cases
+- database access isolated in repository or gateway classes
+- templates or frontend views separated from server-side actions
+- background jobs for file processing and email when appropriate
+
+## Recommended technical direction
+
+Because no developers on the team currently write PHP, the best long-term direction is not PHP modernization. The better choice is a rewrite into a language the team can actively maintain.
+
+For this repository, Python is the strongest default choice.
+
+## Language choice: Python vs JavaScript
+
+### Recommended option: Python
+
+Python is the best fit for this system.
+
+Why:
+
+- the application is backend-heavy, not frontend-heavy
+- it contains file processing, database-heavy workflows, and email sending
+- it will likely benefit from background jobs and scheduled processing
+- it integrates well with both MySQL and SQL Server
+- it is a strong fit for internal business systems and admin-style workflows
+
+This repo is not primarily a reactive UI product. It is a workflow application with forms, imports, database writes, reporting, and operational logic. That profile fits Python better than JavaScript.
+
+Recommended Python stack:
+
+- Django for the main application framework
+- PostgreSQL for the new primary database unless there is a hard requirement to remain on MySQL
+- Celery or RQ for background jobs and file-processing tasks
+- pytest for tests
+- SQLAlchemy or Django ORM depending on whether the rewrite is Django-first or service-first
+- pyodbc or another supported SQL Server connector for the sqlserwebb migration path
+
+Why Django specifically:
+
+- strong support for forms, validation, sessions, auth, and admin workflows
+- good fit for internal tools and operational back-office systems
+- clear project structure out of the box
+- mature ecosystem and predictable deployment model
+
+### Secondary option: JavaScript or TypeScript
+
+JavaScript can work, but it is not the best default choice for this repo unless the future team is already much stronger in Node.js or TypeScript than in Python.
+
+It would be more attractive if:
+
+- the organization wants one language across frontend and backend
+- the future UI is expected to be much richer and API-driven
+- the team already has strong operational experience with Node.js services
+
+If JavaScript is chosen, use TypeScript rather than plain JavaScript.
+
+Recommended JS/TS stack:
+
+- NestJS for a structured backend
+- PostgreSQL as the main database
+- BullMQ or another worker system for background processing
+- Prisma or TypeORM for persistence
+- Jest or Vitest for tests
+
+### Recommendation summary
+
+If the goal is to replace this legacy PHP system with a maintainable, production-ready codebase that matches the application's actual workload, choose Python.
+
+Choose JavaScript or TypeScript only if team capability strongly favors it.
+
+## Rewrite strategy
+
+There are two realistic paths.
+
+### Option A: Rewrite incrementally into Python
+
+This is the recommended path.
+
+Suggested approach:
+
+- keep the current PHP app running during migration
+- rewrite one bounded workflow at a time
+- start with ISBN first because it is relatively well-bounded
+- move DiVA import processing next
+- migrate sqlserwebb later because its SQL Server dependency makes it a separate integration concern
+
+Why this is the best fit:
+
+- the team can maintain the new code
+- the architecture can be designed around current business boundaries instead of page scripts
+- Python is a better long-term fit for workflow processing, admin logic, and jobs
+
+### Option B: Rewrite selected workflows into separate services
+
+This is only worth doing after the domain boundaries are understood and tested.
+
+Possible split:
+
+- ISBN as its own service
+- import/file-processing pipeline as its own worker-oriented service
+- sqlserwebb as a separately deployed integration app because it depends on SQL Server
+
+This can make sense long term, but it is more expensive and easier to get wrong if attempted too early.
+
+## Proposed module boundaries
+
+If the code remains in one repository, reorganize it around domains instead of page names.
+
+Suggested top-level application areas:
+
+- `src/Application`
+  - use cases, orchestration, transactions
+- `src/Domain`
+  - domain models, business rules, value objects
+- `src/Infrastructure`
+  - MySQL, SQL Server, mail, filesystem, logging, external integrations
+- `src/Web`
+  - controllers, request validation, response mapping, templates or APIs
+
+Suggested business modules:
+
+- `DiVA`
+- `ISBN`
+- `BIBMET`
+- `SqlSerWebb`
+- `Shared`
+
+## Production-ready baseline
+
+Before any larger rewrite, the system should meet this minimum baseline.
+
+### Runtime and dependencies
+
+- choose one supported target runtime for the rewrite, preferably Python
+- manage dependencies through a standard package manager and lockfile
+- stop vendoring libraries directly unless there is a specific reason
+- pin dependency versions and scan them in CI
+
+### Configuration and secrets
+
+- replace mounted ad hoc config files with environment-based configuration
+- use a single configuration contract for all environments
+- keep secrets out of the repository and out of image layers
+- document every required environment variable
+
+### Containers and deployment
+
+- keep one production Dockerfile and one local/dev override only if truly necessary
+- add explicit health checks for app and database
+- run the app as a non-root user where possible
+- make logs go to stdout/stderr in structured form
+- define rollback-safe deployment behavior
+
+### Observability
+
+- add application logs with correlation/request IDs
+- capture application errors centrally
+- add simple health endpoints such as `/health` and `/ready`
+- define basic metrics: request count, error rate, job failures, queue depth if jobs are introduced
+
+### Security
+
+- audit all direct SQL construction and remove unsafe query patterns
+- use prepared statements everywhere
+- add CSRF protection to state-changing forms
+- review session settings and cookie flags
+- validate uploads by size, type, and storage path
+- avoid exposing detailed PHP errors in production
+
+### Quality gates
+
+- add unit tests for business-critical ISBN and import logic
+- add integration tests for database workflows
+- add a smoke test for the main entry points
+- run linting, static analysis, and tests in CI on every pull request
+
+## Practical migration plan
+
+### Phase 1: Stabilize what exists
+
+Goal: reduce operational risk without changing core behavior.
+
+Actions:
+
+- centralize configuration loading
+- remove remaining hardcoded credentials and runtime assumptions
+- standardize database connection creation
+- standardize error handling and logging
+- add minimal health checks and CI validation
+- document all databases, tables, and external dependencies
+
+Deliverable:
+
+- the current application still works, but it is easier to run and safer to deploy
+
+### Phase 2: Extract shared infrastructure
+
+Goal: stop repeating low-level code in page scripts.
+
+Actions:
+
+- create shared database clients for MySQL and SQL Server
+- create mail service wrapper around PHPMailer
+- create shared config object
+- create reusable validation helpers
+- create a small request/response abstraction or introduce a framework front controller
+
+Deliverable:
+
+- page scripts become thinner and easier to replace over time
+
+### Phase 3: Move business logic into services
+
+Goal: separate use cases from HTTP pages.
+
+Examples:
+
+- `ReserveIsbnService`
+- `RegisterIsbnService`
+- `ProcessDivaImportService`
+- `SyncOrcidService`
+- `ManageAddressRuleService`
+
+Deliverable:
+
+- the important rules live in tested service classes instead of in page scripts
+
+### Phase 4: Introduce modern web entry points
+
+Goal: replace direct script-per-page routing with a coherent application surface.
+
+Actions:
+
+- introduce controller-based routing
+- validate all input at the edge
+- move rendering into templates or a frontend layer
+- keep old endpoints temporarily as adapters until migration is complete
+
+Deliverable:
+
+- new code enters through a consistent architecture while old pages still work during transition
+
+### Phase 5: Split deployable units only if needed
+
+Goal: separate modules only after they are stable and well understood.
+
+Good candidates:
+
+- async import processing
+- sqlserwebb, because it has different infrastructure needs
+- ISBN, if it needs a separate lifecycle or API consumers
+
+Deliverable:
+
+- smaller deployment units with lower blast radius, if the operational value justifies the complexity
+
+## Immediate high-value refactors in this repo
+
+These changes would improve coherence quickly without requiring a rewrite.
+
+1. Introduce one shared bootstrap file.
+   It should initialize config, logging, session handling, and database factories.
+
+2. Move all DB credentials and database names behind one config layer.
+   The app currently mixes environment-specific assumptions with runtime code.
+
+3. Create dedicated data access classes per database.
+   At minimum:
+   - `HantDivaRepository`
+   - `HantIsbnRepository`
+   - `BibmetRepository`
+   - `BibstatRepository`
+
+4. Wrap email sending behind a service.
+   Page scripts should not instantiate PHPMailer directly.
+
+5. Extract ISBN logic first.
+   ISBN reservation/registration is a relatively bounded domain and is a strong candidate for the first clean service layer.
+
+6. Isolate file processing from browser requests.
+   Long-running import jobs should eventually move to background processing instead of happening entirely in request/response flow.
+
+7. Treat sqlserwebb as an integration boundary.
+   It depends on SQL Server and should be separated logically even if it stays in the same repo at first.
+
+## Suggested directory shape after a first modernization step
+
+```text
+src/
+  Application/
+    DiVA/
+    ISBN/
+    BIBMET/
+    SqlSerWebb/
+  Domain/
+    DiVA/
+    ISBN/
+    BIBMET/
+    Shared/
+  Infrastructure/
+    Database/
+    Mail/
+    Logging/
+    Filesystem/
+    Config/
+  Web/
+    Controller/
+    Middleware/
+    View/
+public/
+tests/
+config/
+docker/
+```
+
+## What should not be done
+
+- do not rewrite everything at once
+- do not change database schema and application behavior in the same large step unless there is strong test coverage
+- do not introduce microservices just to appear modern
+- do not keep adding new features to legacy page scripts once replacement services exist
+
+## A sensible end-state
+
+A coherent production-ready PI would look like this:
+
+- a supported target runtime, preferably Python
+- package-managed dependencies with a lockfile
+- framework-based request lifecycle
+- typed service layer for business logic
+- isolated data access for MySQL and SQL Server
+- background processing for heavy file workflows
+- structured logs, health checks, and CI quality gates
+- environment-driven config and secret management
+- clear ownership boundaries between DiVA, ISBN, BIBMET, and sqlserwebb
+
+## Recommended next steps
+
+1. Confirm Python as the rewrite target and select Django or FastAPI.
+2. Model the ISBN workflow first as the first replacement module.
+3. Extract shared config, DB, and mail integrations behind clean service interfaces.
+4. Add tests around ISBN and DiVA import behavior before larger migrations.
+5. Decide whether sqlserwebb stays inside the app or becomes a separately deployed integration module.
+
+If this project is going to be improved under active production use, incremental modernization is the correct strategy. A full rewrite should only happen after the domain behavior is captured by tests and the system boundaries are explicit.

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,47 @@
+services:
+  pi:
+    container_name: pi-local
+    build:
+      context: .
+      dockerfile: Dockerfile.local
+    depends_on:
+      - pi-db
+    ports:
+      - "8080:80"
+    environment:
+      PI_DB_HOST: pi-db
+      PI_DB_USER: root
+      PI_DB_PASSWORD: root
+      PI_DB_DIVA_NAME: hant_diva
+      PI_DB_ISBN_NAME: hant_isbn
+      PI_DB_BIBMET_NAME: bibmet
+    restart: unless-stopped
+    networks:
+      - pi-local-net
+
+  pi-db:
+    container_name: pi-db-local
+    image: mysql:8.0
+    volumes:
+      - persistent-pi-db-local:/var/lib/mysql
+      - ./dbinit:/docker-entrypoint-initdb.d
+    ports:
+      - "3307:3306"
+    restart: unless-stopped
+    command:
+      - --default-authentication-plugin=mysql_native_password
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
+    environment:
+      LANG: C.UTF-8
+      MYSQL_ROOT_PASSWORD: root
+    networks:
+      - pi-local-net
+
+volumes:
+  persistent-pi-db-local:
+
+networks:
+  pi-local-net:
+    driver: bridge

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -8,13 +8,15 @@ services:
       - pi-db
     ports:
       - "8080:80"
+    env_file:
+      - .env
     environment:
-      PI_DB_HOST: pi-db
-      PI_DB_USER: root
-      PI_DB_PASSWORD: root
-      PI_DB_DIVA_NAME: hant_diva
-      PI_DB_ISBN_NAME: hant_isbn
-      PI_DB_BIBMET_NAME: bibmet
+      PI_DB_HOST: ${PI_DB_HOST}
+      PI_DB_USER: ${PI_DB_USER}
+      PI_DB_PASSWORD: ${PI_DB_PASSWORD}
+      PI_DB_DIVA_NAME: ${PI_DB_DIVA_NAME}
+      PI_DB_ISBN_NAME: ${PI_DB_ISBN_NAME}
+      PI_DB_BIBMET_NAME: ${PI_DB_BIBMET_NAME}
     restart: unless-stopped
     networks:
       - pi-local-net
@@ -35,7 +37,7 @@ services:
       - --sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
     environment:
       LANG: C.UTF-8
-      MYSQL_ROOT_PASSWORD: root
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-localroot}
     networks:
       - pi-local-net
 

--- a/src/PI/DiVA/d_h_loggain.php
+++ b/src/PI/DiVA/d_h_loggain.php
@@ -29,9 +29,9 @@
 
         try {
             
-	    $username = "pi_anv";
-            $password = "V#puBL09";
-            $dbname = "hant_diva";
+	    $username = $db_user;
+            $password = $db_pass;
+            $dbname = $diva_dbname;
             $dbh = new PDO("mysql:host=$hostname;dbname=$dbname", $username, $password);
             $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
             $_SESSION['anv'] = $username;

--- a/src/PI/DiVA/d_h_meny.php
+++ b/src/PI/DiVA/d_h_meny.php
@@ -29,9 +29,9 @@
 
         try {
             
-	    $username = "pi_anv";
-            $password = "V#puBL09";
-            $dbname = "hant_diva";
+	    $username = $db_user;
+            $password = $db_pass;
+            $dbname = $diva_dbname;
             $dbh = new PDO("mysql:host=$hostname;dbname=$dbname", $username, $password);
             $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
             $_SESSION['anv'] = $username;

--- a/src/PI/DiVA/index.php
+++ b/src/PI/DiVA/index.php
@@ -29,9 +29,9 @@
 
         try {
             
-	    $username = "pi_anv";
-            $password = "V#puBL09";
-            $dbname = "hant_diva";
+	    $username = $db_user;
+            $password = $db_pass;
+            $dbname = $diva_dbname;
             $dbh = new PDO("mysql:host=$hostname;dbname=$dbname", $username, $password);
             $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
             $_SESSION['anv'] = $username;


### PR DESCRIPTION
* Add local runtime files with Docker-only startup via docker-compose.local.yml and Dockerfile.local.
* Configure local web and MySQL services with mapped ports and initialized dbinit schema data.
* Replace hardcoded DiVA DB credentials with config variables to support environment-based settings.
* Document a full English local quickstart in README, including verify, logs, reset, and troubleshooting.
> Note: This PR was initially generated with AI assistance and then refactored and cleaned up by the author.
<img width="736" height="278" alt="Screenshot 2026-04-21 at 16 02 14" src="https://github.com/user-attachments/assets/b8fb59fc-e659-42b2-8632-3fa7e00b2724" />
